### PR TITLE
Problem. Memory leak when applying .searchable and .refreshable modifiers together on a ScrollView.

### DIFF
--- a/Bugs/MemoryLeakSearchableRefreshableScrollView/MRE.swift
+++ b/Bugs/MemoryLeakSearchableRefreshableScrollView/MRE.swift
@@ -1,0 +1,56 @@
+//
+//  ContentView.swift
+//  MRE
+//
+//  Created by VAndrJ on 2/1/25.
+//
+
+import SwiftUI
+
+/// Example for easy reproduction.
+/// Run. Go to TestView/back several times and observe the memory report.
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            NavigationLink("Next") {
+                TestView()
+            }
+        }
+    }
+}
+
+struct TestView: View {
+    @StateObject var vm2 = ObservableObjectViewModel()
+    @State var array = Array(1...2_000_000)
+    @State var text = ""
+    let num = 10
+
+    var body: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(0...10, id: \.self) {
+                    Text("\($0)")
+                }
+            }
+        }
+        /// Problem
+        .refreshable {
+            print(num)
+        }
+        .searchable(text: $text)
+    }
+}
+
+class ObservableObjectViewModel: ObservableObject {
+    let id = UUID()
+    let array = Array(1...2_000_000)
+
+    init() {
+        print(#function, Self.self, id)
+    }
+
+    deinit {
+        print(#function, Self.self, id)
+    }
+}
+

--- a/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md
+++ b/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md
@@ -24,7 +24,7 @@ Using capture list.
 A video demonstrating how it behaves on iOS 17.2 without a memory leak and on iOS 18.2 with a memory leak.
 
 
-upload video.
+https://github.com/user-attachments/assets/56ebfc9c-8afc-43be-8f7b-cf8699219853
 
 
 ## Additions

--- a/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md
+++ b/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md
@@ -1,0 +1,34 @@
+## Problem
+
+
+The `.searchable` and `.refreshable` modifiers on `ScrollView` cause a memory leak when applied together.
+
+
+## Environment
+
+
+- Xcode 16.0-16.2 (current; check on future versions).
+- iOS 17.3-18.2 (current; check on future versions).
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+Using capture list.
+
+
+## Demo
+
+
+A video demonstrating how it behaves on iOS 17.2 without a memory leak and on iOS 18.2 with a memory leak.
+
+
+upload video.
+
+
+## Additions
+
+
+Сritical issue.
+

--- a/Bugs/MemoryLeakSearchableRefreshableScrollView/Solution.swift
+++ b/Bugs/MemoryLeakSearchableRefreshableScrollView/Solution.swift
@@ -1,0 +1,57 @@
+//
+//  ContentView.swift
+//  MRE
+//
+//  Created by VAndrJ on 2/1/25.
+//
+
+import SwiftUI
+
+/// Solution / Workaround
+/// Example for easy reproduction.
+/// Run. Go to TestView/back several times and observe the memory report.
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            NavigationLink("Next") {
+                TestView()
+            }
+        }
+    }
+}
+
+struct TestView: View {
+    @StateObject var vm2 = ObservableObjectViewModel()
+    @State var array = Array(1...2_000_000)
+    @State var text = ""
+    let num = 10
+
+    var body: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(0...10, id: \.self) {
+                    Text("\($0)")
+                }
+            }
+        }
+        /// Solution / Workaround:
+        .refreshable { [num] in
+            print(num)
+        }
+        .searchable(text: $text)
+    }
+}
+
+class ObservableObjectViewModel: ObservableObject {
+    let id = UUID()
+    let array = Array(1...2_000_000)
+
+    init() {
+        print(#function, Self.self, id)
+    }
+
+    deinit {
+        print(#function, Self.self, id)
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 ## UI Frameworks
 
 
+- [Memory leak](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md) when applying `.searchable` and `.refreshable` modifiers together on a `ScrollView`.
+
+
 ### SwiftUI
 
 
@@ -35,6 +38,9 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 
 
 ### iOS
+
+
+- [Memory leak](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md) when applying `.searchable` and `.refreshable` modifiers together on a `ScrollView`.
 
 
 ### iPadOS


### PR DESCRIPTION
Problem. Memory leak when applying .searchable and .refreshable modifiers together on a ScrollView.