### PR TITLE
The button action is not canceled during scrolling in a sheet and is executed after scrolling completes.

### DIFF
--- a/Bugs/ButtonActionNotCancelledDuringScrollInSheet/MRE.swift
+++ b/Bugs/ButtonActionNotCancelledDuringScrollInSheet/MRE.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// The button action is not canceled during scrolling in sheet and is executed after scrolling completes.
+/// The button action is not canceled during scrolling in a sheet and is executed after scrolling completes.
 struct ContentView: View {
     @State private var isSheetPresented = false
 

--- a/Bugs/ButtonActionNotCancelledDuringScrollInSheet/MRE.swift
+++ b/Bugs/ButtonActionNotCancelledDuringScrollInSheet/MRE.swift
@@ -1,0 +1,34 @@
+//
+//  SceneDelegate.swift
+//  MRE
+//
+//  Created by VAndrJ on 2/3/25.
+//
+
+import SwiftUI
+
+/// The button action is not canceled during scrolling in sheet and is executed after scrolling completes.
+struct ContentView: View {
+    @State private var isSheetPresented = false
+
+    var body: some View {
+        Button("Open sheet") {
+            isSheetPresented = true
+        }
+        .sheet(isPresented: $isSheetPresented) {
+            ScrollView {
+                LazyVStack(spacing: 16) {
+                    ForEach(0..<30, id: \.self) { index in
+                        Button {
+                            print("\(index) button action")
+                        } label: {
+                            Text("\(index) button")
+                                .frame(maxWidth: .infinity, idealHeight: 64)
+                        }
+                        .buttonStyle(BorderedProminentButtonStyle())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md
+++ b/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md
@@ -1,7 +1,7 @@
 ## Problem
 
 
-The button action is not canceled during scrolling in sheet and is executed after scrolling completes.
+The button action is not canceled during scrolling in a sheet and is executed after scrolling completes.
 
 
 ## Environment
@@ -24,7 +24,7 @@ Build in Xcode 15.4.
 Video showing how it works on iOS 17 and iOS 18.
 
 
-upload video.
+https://github.com/user-attachments/assets/028762ed-958b-485a-9eb8-bc108245a920
 
 
 ## Additions

--- a/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md
+++ b/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md
@@ -1,0 +1,34 @@
+## Problem
+
+
+The button action is not canceled during scrolling in sheet and is executed after scrolling completes.
+
+
+## Environment
+
+
+- Xcode 16.0-16.2 (current; check on future versions).
+- iOS 18.0-18.2 (current; check on future versions).
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+Build in Xcode 15.4.
+
+
+## Demo
+
+
+Video showing how it works on iOS 17 and iOS 18.
+
+
+upload video.
+
+
+## Additions
+
+
+This is most likely related to other gesture issues that were introduced in Xcode 16+iOS 18.
+

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 
 - [Memory leak](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md) when applying `.searchable` and `.refreshable` modifiers together on a `ScrollView`.
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
+- [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in sheet and is executed after scrolling completes.
 
 
 ### UIKit
@@ -50,6 +51,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Memory leak](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md) when applying `.searchable` and `.refreshable` modifiers together on a `ScrollView`.
 - [Crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CrashTypedThrowsObservableObject/README.md) occurs when using a typed throws in a closure variable within an `ObservableObject`.
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
+- [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in sheet and is executed after scrolling completes.
 
 
 ### iPadOS

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 
 - [Memory leak](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md) when applying `.searchable` and `.refreshable` modifiers together on a `ScrollView`.
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
-- [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in sheet and is executed after scrolling completes.
+- [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in a sheet and is executed after scrolling completes.
 
 
 ### UIKit
@@ -51,7 +51,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Memory leak](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md) when applying `.searchable` and `.refreshable` modifiers together on a `ScrollView`.
 - [Crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CrashTypedThrowsObservableObject/README.md) occurs when using a typed throws in a closure variable within an `ObservableObject`.
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
-- [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in sheet and is executed after scrolling completes.
+- [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in a sheet and is executed after scrolling completes.
 
 
 ### iPadOS


### PR DESCRIPTION
The button action is not canceled during scrolling in a sheet and is executed after scrolling completes.
