### PR TITLE
Gesture issue: `.updating` block is not called on `LongPressGesture`.

### DIFF
--- a/Bugs/GestureIssueLongPressUpdatingNotCalled/MRE.swift
+++ b/Bugs/GestureIssueLongPressUpdatingNotCalled/MRE.swift
@@ -1,0 +1,40 @@
+//
+//  ContentView.swift
+//  MRE
+//
+//  Created by VAndrJ on 2/3/25.
+//
+
+import SwiftUI
+import Observation
+
+/// Gesture issue: `.updating` block is not called on `LongPressGesture`.
+/// https://developer.apple.com/documentation/swiftui/longpressgesture example
+struct ContentView: View {
+    @GestureState private var isDetectingLongPress = false
+    @State private var completedLongPress = false
+
+
+    var longPress: some Gesture {
+        LongPressGesture(minimumDuration: 3)
+            .updating($isDetectingLongPress) { currentState, gestureState,
+                transaction in
+                gestureState = currentState
+                transaction.animation = Animation.easeIn(duration: 2.0)
+            }
+            .onEnded { finished in
+                self.completedLongPress = finished
+            }
+    }
+
+
+    var body: some View {
+        Circle()
+            .fill(self.isDetectingLongPress ?
+                  Color.red :
+                    (self.completedLongPress ? Color.green : Color.blue))
+            .frame(width: 100, height: 100, alignment: .center)
+            .gesture(longPress)
+    }
+}
+

--- a/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md
+++ b/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md
@@ -1,0 +1,36 @@
+## Problem
+
+
+Gesture issue: `.updating` block is not called on `LongPressGesture`.
+
+
+## Environment
+
+
+- Xcode 16.0-16.2 (current; check on future versions).
+- iOS 18.0-18.2 (current; check on future versions).
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+- Build with Xcode 15.4.
+- Use different gestures.
+
+
+## Demo
+
+
+A video demonstrating how it behaves on iOS 18 and on iOS 17.
+
+
+upload video.
+
+
+## Additions
+
+
+Known issue. Shoul be fixed in future releases [FB16430342](https://feedbackassistant.apple.com/feedback/16430342)
+
+

--- a/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md
+++ b/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md
@@ -25,7 +25,7 @@ Gesture issue: `.updating` block is not called on `LongPressGesture`.
 A video demonstrating how it behaves on iOS 18 and on iOS 17.
 
 
-upload video.
+https://github.com/user-attachments/assets/d218c595-fcb7-498d-b2d0-39e3d4f007e6
 
 
 ## Additions

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Memory leak](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md) when applying `.searchable` and `.refreshable` modifiers together on a `ScrollView`.
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
 - [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in a sheet and is executed after scrolling completes.
+- [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
 
 
 ### UIKit


### PR DESCRIPTION
Gesture issue: `.updating` block is not called on `LongPressGesture`.