### PR TITLE
NavigationStack issue: popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.

### DIFF
--- a/Bugs/NavigationStackIssuePoppingBackIsPresented/MRE.swift
+++ b/Bugs/NavigationStackIssuePoppingBackIsPresented/MRE.swift
@@ -1,0 +1,67 @@
+//
+//  ContentView.swift
+//  MRE
+//
+//  Created by VAndrJ on 2/3/25.
+//
+
+import SwiftUI
+
+/// NavigationStack issue: popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.
+struct ContentView: View {
+    @State private var isFirstScreenPushed = false
+
+    var body: some View {
+        NavigationStack {
+            Button("Push first") {
+                isFirstScreenPushed = true
+            }
+            .navigationTitle("Root")
+            .navigationDestination(isPresented: $isFirstScreenPushed) {
+                FirstScreen(isFirstScreenPushed: $isFirstScreenPushed)
+            }
+        }
+    }
+}
+
+struct FirstScreen: View {
+    @Binding var isFirstScreenPushed: Bool
+
+    @State private var isSecondScreenPushed = false
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Button("Push second") {
+                isSecondScreenPushed = true
+            }
+            Button("Back to root") {
+                isFirstScreenPushed = false
+            }
+        }
+        .navigationTitle("First")
+        .navigationDestination(isPresented: $isSecondScreenPushed) {
+            SecondScreen(
+                isFirstScreenPushed: $isFirstScreenPushed,
+                isSecondScreenPushed: $isSecondScreenPushed
+            )
+        }
+    }
+}
+
+struct SecondScreen: View {
+    @Binding var isFirstScreenPushed: Bool
+    @Binding var isSecondScreenPushed: Bool
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Button("Back") {
+                isSecondScreenPushed = false
+            }
+            Button("Back to root") {
+                isFirstScreenPushed = false
+            }
+        }
+        .navigationTitle("Second")
+    }
+}
+

--- a/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md
+++ b/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md
@@ -24,7 +24,7 @@ Use array-based navigation path.
 A video demonstrating how it behaves on iOS 16 and on iOS 17.
 
 
-upload video.
+https://github.com/user-attachments/assets/0b98cf13-89b6-4200-8707-13f087c50684
 
 
 ## Additions

--- a/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md
+++ b/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md
@@ -1,0 +1,35 @@
+## Problem
+
+
+`NavigationStack` issue: Popping back programmatically doesn’t work for navigation deeper than one level when using `.navigationDestination(isPresented:)`.
+
+
+## Environment
+
+
+- Xcode 16.
+- iOS 16.0-16.2.
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+Use array-based navigation path.
+
+
+## Demo
+
+
+A video demonstrating how it behaves on iOS 16 and on iOS 17.
+
+
+upload video.
+
+
+## Additions
+
+
+One of the many problems with `NavigationStack`.
+
+

--- a/Bugs/NavigationStackIssuePoppingBackIsPresented/Solution.swift
+++ b/Bugs/NavigationStackIssuePoppingBackIsPresented/Solution.swift
@@ -1,0 +1,70 @@
+//
+//  ContentView.swift
+//  MRE
+//
+//  Created by VAndrJ on 2/3/25.
+//
+
+import SwiftUI
+
+/// Solution / Workaround.
+/// NavigationStack issue: popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.
+enum Destination {
+    case firstScreen
+    case secondScreen
+}
+
+struct ContentView: View {
+    /// Solution / Workaround.
+    @State private var path: [Destination] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            Button("Push first") {
+                path.append(.firstScreen)
+            }
+            .navigationTitle("Root")
+            .navigationDestination(for: Destination.self, destination: { screen in
+                switch screen {
+                case .firstScreen:
+                    FirstScreen(path: $path)
+                case .secondScreen:
+                    SecondScreen(path: $path)
+                }
+            })
+        }
+    }
+}
+
+struct FirstScreen: View {
+    @Binding var path: [Destination]
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Button("Push second") {
+                path.append(.secondScreen)
+            }
+            Button("Back to root") {
+                path.removeAll()
+            }
+        }
+        .navigationTitle("First")
+    }
+}
+
+struct SecondScreen: View {
+    @Binding var path: [Destination]
+
+    var body: some View {
+        VStack(spacing: 32) {
+            Button("Back") {
+                path.removeLast()
+            }
+            Button("Back to root") {
+                path.removeAll()
+            }
+        }
+        .navigationTitle("Second")
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
 - [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in a sheet and is executed after scrolling completes.
 - [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
+- [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md): popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.
 
 
 ### UIKit


### PR DESCRIPTION
NavigationStack issue: popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.