### PR TITLE
`NavigationStack` issue: when clearing a path, it does not go back if there was a transition with an active `.searchable`.

### DIFF
--- a/Bugs/NavigationStackIssuePathClearActiveSearchable/MRE.swift
+++ b/Bugs/NavigationStackIssuePathClearActiveSearchable/MRE.swift
@@ -1,0 +1,48 @@
+//
+//  ContentView.swift
+//  MRE
+//
+//  Created by VAndrJ on 2/3/25.
+//
+
+import SwiftUI
+
+/// NavigationStack issue: when clearing a path, it does not go back if there was a transition with an active .searchable.
+struct ContentView: View {
+    @State private var path: [String] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            ExampleView(path: $path, title: "Root")
+                .navigationDestination(for: String.self) { title in
+                    ExampleView(path: $path, title: title)
+                }
+        }
+    }
+}
+
+struct ExampleView: View {
+    @Binding var path: [String]
+    let title: String
+
+    @State private var text = ""
+
+    var body: some View {
+        Text(#"Enter the title and press "search""#)
+            .navigationBarTitle(title)
+            .toolbar {
+                if !path.isEmpty {
+                    ToolbarItem {
+                        Button("Root") {
+                            path.removeAll()
+                        }
+                    }
+                }
+            }
+            .searchable(text: $text)
+            .onSubmit(of: .search) {
+                path.append(text)
+            }
+    }
+}
+

--- a/Bugs/NavigationStackIssuePathClearActiveSearchable/README.md
+++ b/Bugs/NavigationStackIssuePathClearActiveSearchable/README.md
@@ -24,7 +24,7 @@ Use the `.searchable(text:isPresented:)` modifier and set `isPresented` variable
 A video demonstrating how it behaves on iOS 17 and on iOS 18.
 
 
-upload video.
+https://github.com/user-attachments/assets/9d89f6c4-20c1-4d19-a02b-0acb03866d7e
 
 
 ## Additions

--- a/Bugs/NavigationStackIssuePathClearActiveSearchable/README.md
+++ b/Bugs/NavigationStackIssuePathClearActiveSearchable/README.md
@@ -1,0 +1,35 @@
+## Problem
+
+
+`NavigationStack` issue: when clearing a path, it does not go back if there was a transition with an active `.searchable`.
+
+
+## Environment
+
+
+- Xcode 16.0-16.2 (current; check on future versions).
+- iOS 18.0-18.3 (current; check on future versions).
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+Use the `.searchable(text:isPresented:)` modifier and set `isPresented` variable to `false` before the transition, making it inactive.
+
+
+## Demo
+
+
+A video demonstrating how it behaves on iOS 17 and on iOS 18.
+
+
+upload video.
+
+
+## Additions
+
+
+One of the many problems with `NavigationStack`:
+- [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md): popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.
+

--- a/Bugs/NavigationStackIssuePathClearActiveSearchable/Solution.swift
+++ b/Bugs/NavigationStackIssuePathClearActiveSearchable/Solution.swift
@@ -1,0 +1,52 @@
+//
+//  ContentView.swift
+//  MRE
+//
+//  Created by VAndrJ on 2/3/25.
+//
+
+import SwiftUI
+
+/// Solution / Workaround.
+/// NavigationStack issue: when clearing a path, it does not go back if there was a transition with an active .searchable.
+struct ContentView: View {
+    @State private var path: [String] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            ExampleView(path: $path, title: "Root")
+                .navigationDestination(for: String.self) { title in
+                    ExampleView(path: $path, title: title)
+                }
+        }
+    }
+}
+
+struct ExampleView: View {
+    @Binding var path: [String]
+    let title: String
+
+    @State private var text = ""
+    @State private var isSearchPresented = false
+
+    var body: some View {
+        Text(#"Enter the title and press "search""#)
+            .navigationBarTitle(title)
+            .toolbar {
+                if !path.isEmpty {
+                    ToolbarItem {
+                        Button("Root") {
+                            path.removeAll()
+                        }
+                    }
+                }
+            }
+            .searchable(text: $text, isPresented: $isSearchPresented)
+            .onSubmit(of: .search) {
+                /// Solution / Workaround.
+                isSearchPresented = false
+                path.append(text)
+            }
+    }
+}
+

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in a sheet and is executed after scrolling completes.
 - [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
 - [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md): popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.
+- [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePathClearActiveSearchable/README.md): when clearing a path, it does not go back if there was a transition with an active `.searchable`.
 
 
 ### UIKit


### PR DESCRIPTION
`NavigationStack` issue: when clearing a path, it does not go back if there was a transition with an active `.searchable`.