### PR TITLE
Sheet issue: `.presentationDetents` is ignored if the sheet is reopened after a short period.

### DIFF
--- a/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/MRE.swift
+++ b/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/MRE.swift
@@ -1,0 +1,22 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 2/3/25.
+//
+
+import SwiftUI
+
+/// Sheet issue: `.presentationDetents` is ignored if the sheet is reopened after a short period.
+struct ContentView: View {
+    @State private var isSheetPresented = false
+
+    var body: some View {
+        Button("Open Sheet") {
+            isSheetPresented = true
+        }
+        .sheet(isPresented: $isSheetPresented) {
+            Text("Sheet Content")
+                .presentationDetents([.height(480)])
+        }
+    }
+}

--- a/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/README.md
+++ b/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/README.md
@@ -1,0 +1,31 @@
+## Problem
+
+
+Sheet issue: `.presentationDetents` is ignored if the sheet is reopened after a short period.
+
+
+## Environment
+
+
+- Xcode 16.0-16.2 (current; check on future versions).
+- iOS 18.0-18.3 (current; check on future versions).
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+Allow `.sheet` to be presented again only after a short delay.
+
+
+## Demo
+
+
+A video demonstrating how it behaves on iOS 18.
+
+
+upload video.
+
+
+## Additions
+

--- a/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/README.md
+++ b/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/README.md
@@ -24,7 +24,7 @@ Allow `.sheet` to be presented again only after a short delay.
 A video demonstrating how it behaves on iOS 18.
 
 
-upload video.
+https://github.com/user-attachments/assets/9b27c669-5038-4b6d-8d27-39ca18de218d
 
 
 ## Additions

--- a/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/Solution.swift
+++ b/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/Solution.swift
@@ -1,0 +1,32 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 2/3/25.
+//
+
+import SwiftUI
+
+/// Solution / Workaround.
+/// Sheet issue: `.presentationDetents` is ignored if the sheet is reopened after a short period.
+struct ContentView: View {
+    @State private var isSheetPresented = false
+    /// Solution / Workaround
+    @State private var isButtonDisabled = false
+
+    var body: some View {
+        Button("Open Sheet") {
+            isSheetPresented = true
+            isButtonDisabled = true
+        }
+        .disabled(isButtonDisabled)
+        .sheet(isPresented: $isSheetPresented, onDismiss: {
+            /// Delay to make the button active when the sheet is dismissed or in any other way.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                isButtonDisabled = false
+            }
+        }) {
+            Text("Sheet Content")
+                .presentationDetents([.height(480)])
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
 - [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md): popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.
 - [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePathClearActiveSearchable/README.md): when clearing a path, it does not go back if there was a transition with an active `.searchable`.
+- [Sheet issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/README.md): `.presentationDetents` is ignored if the sheet is reopened after a short period.
 
 
 ### UIKit
@@ -65,6 +66,10 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CrashTypedThrowsObservableObject/README.md) occurs when using a typed throws in a closure variable within an `ObservableObject`.
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
 - [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in a sheet and is executed after scrolling completes.
+- [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
+- [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md): popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.
+- [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePathClearActiveSearchable/README.md): when clearing a path, it does not go back if there was a transition with an active `.searchable`.
+- [Sheet issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/README.md): `.presentationDetents` is ignored if the sheet is reopened after a short period.
 
 
 ### iPadOS


### PR DESCRIPTION
Sheet issue: `.presentationDetents` is ignored if the sheet is reopened after a short period.