### PR TITLE
Gesture issue: when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.

### DIFF
--- a/Bugs/GestureIssueHighPriorityToListScrolling/MRE.swift
+++ b/Bugs/GestureIssueHighPriorityToListScrolling/MRE.swift
@@ -1,0 +1,32 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 2/4/25.
+//
+
+import SwiftUI
+
+/// Gesture issue: when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.
+struct ContentView: View {
+    @State private var translationWidth = 0.0
+
+    var body: some View {
+        VStack {
+            List(0...1000, id: \.self) {
+                Text("\($0)")
+            }
+            Text("\(translationWidth)")
+                .padding(16)
+        }
+        .highPriorityGesture(
+            DragGesture()
+                .onChanged {
+                    translationWidth = $0.translation.width
+                }
+                .onEnded { _ in
+                    translationWidth = 0
+                }
+        )
+    }
+}
+

--- a/Bugs/GestureIssueHighPriorityToListScrolling/README.md
+++ b/Bugs/GestureIssueHighPriorityToListScrolling/README.md
@@ -1,0 +1,34 @@
+## Problem
+
+
+Gesture issue: when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.
+
+
+## Environment
+
+
+- Xcode 16.0-16.2 (current; check on future versions).
+- iOS 18.0-18.3 (current; check on future versions).
+- iPadOS 18.0-18.3 (current; check on future versions).
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+- Build with Xcode 15.4.
+- Increase the `minimumDistance` from the default 10 to ~20 or more.
+- Use different gestures.
+
+
+## Demo
+
+
+A video demonstrating how it behaves on iOS 18.
+
+
+upload video.
+
+
+## Additions
+

--- a/Bugs/GestureIssueHighPriorityToListScrolling/Solution.swift
+++ b/Bugs/GestureIssueHighPriorityToListScrolling/Solution.swift
@@ -1,0 +1,34 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 2/4/25.
+//
+
+import SwiftUI
+
+/// Solution / Workaround.
+/// Gesture issue: when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.
+struct ContentView: View {
+    @State private var translationWidth = 0.0
+
+    var body: some View {
+        VStack {
+            List(0...1000, id: \.self) {
+                Text("\($0)")
+            }
+            Text("\(translationWidth)")
+                .padding(16)
+        }
+        .highPriorityGesture(
+            /// Solution / Workaround
+            DragGesture(minimumDistance: 20)
+                .onChanged {
+                    translationWidth = $0.translation.width
+                }
+                .onEnded { _ in
+                    translationWidth = 0
+                }
+        )
+    }
+}
+

--- a/Bugs/GestureIssueLongPressUpdatingNotCalled/MRE.swift
+++ b/Bugs/GestureIssueLongPressUpdatingNotCalled/MRE.swift
@@ -1,6 +1,5 @@
 //
-//  ContentView.swift
-//  MRE
+//  MRE.swift
 //
 //  Created by VAndrJ on 2/3/25.
 //

--- a/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md
+++ b/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md
@@ -8,7 +8,8 @@ Gesture issue: `.updating` block is not called on `LongPressGesture`.
 
 
 - Xcode 16.0-16.2 (current; check on future versions).
-- iOS 18.0-18.2 (current; check on future versions).
+- iOS 18.0-18.3 (current; check on future versions).
+- iPadOS 18.0-18.3 (current; check on future versions).
 - Swift 5/6.
 
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
 - [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in a sheet and is executed after scrolling completes.
 - [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
+- [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueHighPriorityToListScrolling/README.md): when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.
 - [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md): popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.
 - [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePathClearActiveSearchable/README.md): when clearing a path, it does not go back if there was a transition with an active `.searchable`.
 - [Sheet issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/README.md): `.presentationDetents` is ignored if the sheet is reopened after a short period.
@@ -68,6 +69,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
 - [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in a sheet and is executed after scrolling completes.
 - [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
+- [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueHighPriorityToListScrolling/README.md): when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.
 - [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePoppingBackIsPresented/README.md): popping back programmatically doesn't work when using `.navigationDestination(isPresented:)`.
 - [NavigationStack issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationStackIssuePathClearActiveSearchable/README.md): when clearing a path, it does not go back if there was a transition with an active `.searchable`.
 - [Sheet issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/README.md): `.presentationDetents` is ignored if the sheet is reopened after a short period.
@@ -77,6 +79,8 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 
 
 - [Crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CrashTypedThrowsObservableObject/README.md) occurs when using a typed throws in a closure variable within an `ObservableObject`.
+- [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
+- [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueHighPriorityToListScrolling/README.md): when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.
 
 
 ### macOS
@@ -127,6 +131,18 @@ A video demonstrating how it behaves on iOS 18 and iOS 17.
 
 
 https://github.com/user-attachments/assets/d218c595-fcb7-498d-b2d0-39e3d4f007e6
+
+
+---
+
+
+### [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueHighPriorityToListScrolling/README.md): when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.
+
+
+A video demonstrating how it behaves on iOS 18.
+
+
+upload video.
 
 
 ---


### PR DESCRIPTION
Gesture issue: when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.
