### PR TITLE
Alert issue: `.default` and `.cancel` buttons are recolored if alert in a NavigationStack that has tint applied (or higher up the Views tree).

### DIFF
--- a/Bugs/AlertIssueButtonsTintAffectedByModifier/MRE.swift
+++ b/Bugs/AlertIssueButtonsTintAffectedByModifier/MRE.swift
@@ -1,0 +1,34 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 2/7/25.
+//
+
+import SwiftUI
+
+/// Alert issue: `.default` and `.cancel` buttons are recolored if they are in a NavigationStack that has tint applied (or higher up the Views tree).
+struct ContentView: View {
+    @State private var isAlertPresented = false
+    @State private var path: [String] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            Text("Next")
+                .foregroundStyle(.blue)
+                .onTapGesture {
+                    isAlertPresented = true
+                }
+                .alert("Leave?", isPresented: $isAlertPresented) {
+                    Button("Go next") {
+                        path.append("hello") // Doesn't matter for MRE
+                    }
+                    Button("cancel", role: .cancel) {}
+                    Button("destructive", role: .destructive) {}
+                }
+                .navigationDestination(for: String.self) { _ in // Doesn't matter for MRE
+                    Text("Hello, World!")
+                }
+        }
+        .tint(.green)
+    }
+}

--- a/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md
+++ b/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md
@@ -1,0 +1,32 @@
+## Problem
+
+
+Alert issue: `.default` and `.cancel` buttons are recolored if they are in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
+
+
+## Environment
+
+
+- Xcode 16.0-16.2 (current; check on future versions).
+- iOS 18.1.
+- iPadOS 18.1.
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+Move `.alert` above tinted Views branch boundaries.
+
+
+## Demo
+
+
+Video showing how it works on iOS 18.1 and iOS 18.2.
+
+
+upload video
+
+
+## Additions
+

--- a/Bugs/AlertIssueButtonsTintAffectedByModifier/Solution.swift
+++ b/Bugs/AlertIssueButtonsTintAffectedByModifier/Solution.swift
@@ -1,0 +1,36 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 2/7/25.
+//
+
+import SwiftUI
+
+/// Solution / Workaround.
+/// Alert issue: `.default` and `.cancel` buttons are recolored if they are in a NavigationStack that has tint applied (or higher up the Views tree).
+struct ContentView: View {
+    @State private var isAlertPresented = false
+    @State private var path: [String] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            Text("Next")
+                .foregroundStyle(.blue)
+                .onTapGesture {
+                    isAlertPresented = true
+                }
+                .navigationDestination(for: String.self) { _ in // Doesn't matter for MRE
+                    Text("Hello, World!")
+                }
+        }
+        .tint(.green)
+        /// Solution / Workaround
+        .alert("Leave?", isPresented: $isAlertPresented) {
+            Button("Go next") {
+                path.append("hello") // Doesn't matter for MRE
+            }
+            Button("cancel", role: .cancel) {}
+            Button("destructive", role: .destructive) {}
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [NavigationSplitView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationSplitViewToolbarItemDisappearBackground/README.md): toolbar items disappear after the app goes to the background and then returns to the foreground.
 - [TabView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/TabViewIssuePageTabAfterRotation/README.md): wrong tab displayed after rotation when using `.page` style.
 - [@State issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/StateIssueSharedBetweenScenes/README.md): the same variable is shared between different scenes.
+- [Alert issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md): `.default` and `.cancel` buttons are recolored if they are in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
 
 
@@ -83,6 +84,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Sheet issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/SheetIssuePresentationDetentsIgnoredOnReopen/README.md): `.presentationDetents` is ignored if the sheet is reopened after a short period.
 - [TabView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/TabViewIssuePageTabAfterRotation/README.md): wrong tab displayed after rotation when using `.page` style.
 - [@State issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/StateIssueSharedBetweenScenes/README.md): the same variable is shared between different scenes.
+- [Alert issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md): `.default` and `.cancel` buttons are recolored if they are in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
 - [Navigation title](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationTitleQuotationMarksWhitespace/README.md) is displayed in quotation marks `" "` if a whitespace is specified as the title.
 
@@ -97,6 +99,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [NavigationSplitView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationSplitViewToolbarItemDisappearBackground/README.md): toolbar items disappear after the app goes to the background and then returns to the foreground.
 - [TabView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/TabViewIssuePageTabAfterRotation/README.md): wrong tab displayed after rotation when using `.page` style.
 - [@State issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/StateIssueSharedBetweenScenes/README.md): the same variable is shared between different scenes.
+- [Alert issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md): `.default` and `.cancel` buttons are recolored if they are in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
 - [Navigation title](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationTitleQuotationMarksWhitespace/README.md) is displayed in quotation marks `" "` if a whitespace is specified as the title.
 
 
@@ -311,6 +314,18 @@ A video demonstrating how it behaves on iPadOS 17.4 and 17.5.
 
 
 https://github.com/user-attachments/assets/fab3cc1e-9750-47f7-a697-f84d333cd69d
+
+
+---
+
+
+### [Alert issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md): `.default` and `.cancel` buttons are recolored if they are in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
+
+
+Video showing how it works on iOS 18.1 and iOS 18.2.
+
+
+upload video
 
 
 ---


### PR DESCRIPTION
Alert issue: `.default` and `.cancel` buttons are recolored if alert in a NavigationStack that has tint applied (or higher up the Views tree).