### PR TITLE
PhaseAnimator crash: when closing the presented view or popping the pushed view on which it is (or 100% CPU load iOS 17.0).

### DIFF
--- a/Bugs/PhaseAnimatorCrashOnViewClose/MRE.swift
+++ b/Bugs/PhaseAnimatorCrashOnViewClose/MRE.swift
@@ -1,0 +1,73 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 2/14/25.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    @State private var path: [String] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            VStack(spacing: 64) {
+                Button("Next") {
+                    path.append("1")
+                }
+            }
+            .navigationDestination(for: String.self, destination: { _ in
+                BreathingView()
+            })
+        }
+    }
+}
+
+struct BreathingView: View {
+    private let isExpandedPhases: [Bool] = [false, true]
+    private let count = 6
+    private let radius: CGFloat = 64
+
+    var body: some View {
+        VStack {
+            Text("Breathe")
+            PhaseAnimator(isExpandedPhases) { isExpanded in
+                VStack(spacing: 16) {
+                    Text(isExpanded ? "inhale" : "exhale")
+                    ZStack {
+                        ForEach(0..<count, id: \.self) { index in
+                            Circle()
+                                .fill(.teal.opacity(0.6))
+                                .frame(size: .init(same: radius * (isExpanded ? 2 : 1)))
+                                .offset(x: isExpanded ? radius : 0)
+                                .rotationEffect(.radians(.pi * 2 * Double(index) / Double(count)))
+                        }
+                    }
+                    .rotationEffect(.radians(isExpanded ? 0 : -.pi / Double(count) ))
+                    .frame(size: .init(same: radius * 4))
+                }
+            }
+        }
+    }
+}
+
+extension View {
+    @inlinable nonisolated public func frame(
+        size: CGSize,
+        alignment: Alignment = .center
+    ) -> some View {
+        return frame(
+            width: size.width,
+            height: size.height,
+            alignment: alignment
+        )
+    }
+}
+
+extension CGSize {
+
+    init(same: CGFloat) {
+        self.init(width: same, height: same)
+    }
+}
+

--- a/Bugs/PhaseAnimatorCrashOnViewClose/README.md
+++ b/Bugs/PhaseAnimatorCrashOnViewClose/README.md
@@ -1,0 +1,32 @@
+## Problem
+
+
+PhaseAnimator crash: when closing the presented view or popping the pushed view on which it is (or 100% CPU load iOS 17.0).
+
+
+## Environment
+
+
+- Xcode 15-16.2 (current; check on future versions).
+- iOS 17.0-17.3.
+- iPadOS 17.0-17.3.
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+No solution.
+
+
+## Demo
+
+
+A video demonstrating how it behaves on iOS 17.2.
+
+
+upload video
+
+
+## Additions
+

--- a/Bugs/PhaseAnimatorCrashOnViewClose/README.md
+++ b/Bugs/PhaseAnimatorCrashOnViewClose/README.md
@@ -25,7 +25,7 @@ No solution.
 A video demonstrating how it behaves on iOS 17.2.
 
 
-upload video
+https://github.com/user-attachments/assets/0a5bdce3-ba23-477b-b75a-b90f1564261d
 
 
 ## Additions

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [NavigationSplitView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationSplitViewToolbarItemDisappearBackground/README.md): toolbar items disappear after the app goes to the background and then returns to the foreground.
 - [TabView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/TabViewIssuePageTabAfterRotation/README.md): wrong tab displayed after rotation when using `.page` style.
 - [@State issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/StateIssueSharedBetweenScenes/README.md): the same variable is shared between different scenes.
+- [PhaseAnimator crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/PhaseAnimatorCrashOnViewClose/README.md): when closing the presented view or popping the pushed view on which it is (or 100% CPU load iOS 17.0).
 - [Alert issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md): `.default` and `.cancel` buttons are recolored if alert in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
 
@@ -93,6 +94,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Sheet issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/SheetIssueStateRestorationMultiplePresented/README.md): if you have multiple `.sheet`s open, when you restore the state, not all of them will be presented, and after that `.sheet` won't be open even manually until you close the previous one.
 - [TabView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/TabViewIssuePageTabAfterRotation/README.md): wrong tab displayed after rotation when using `.page` style.
 - [@State issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/StateIssueSharedBetweenScenes/README.md): the same variable is shared between different scenes.
+- [PhaseAnimator crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/PhaseAnimatorCrashOnViewClose/README.md): when closing the presented view or popping the pushed view on which it is (or 100% CPU load iOS 17.0).
 - [Alert issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md): `.default` and `.cancel` buttons are recolored if alert in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
 - [Navigation title](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationTitleQuotationMarksWhitespace/README.md) is displayed in quotation marks `" "` if a whitespace is specified as the title.
@@ -108,6 +110,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [NavigationSplitView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationSplitViewToolbarItemDisappearBackground/README.md): toolbar items disappear after the app goes to the background and then returns to the foreground.
 - [TabView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/TabViewIssuePageTabAfterRotation/README.md): wrong tab displayed after rotation when using `.page` style.
 - [@State issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/StateIssueSharedBetweenScenes/README.md): the same variable is shared between different scenes.
+- [PhaseAnimator crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/PhaseAnimatorCrashOnViewClose/README.md): when closing the presented view or popping the pushed view on which it is (or 100% CPU load iOS 17.0).
 - [SwiftData crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/SwiftDataCrashDefaultTemplate/README.md): deleting the element will result in a crash in the standard template.
 - [Alert issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md): `.default` and `.cancel` buttons are recolored if alert in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
 - [Navigation title](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationTitleQuotationMarksWhitespace/README.md) is displayed in quotation marks `" "` if a whitespace is specified as the title.
@@ -338,6 +341,18 @@ A video demonstrating how it behaves on iPadOS 17.4 and 17.5.
 
 
 https://github.com/user-attachments/assets/fab3cc1e-9750-47f7-a697-f84d333cd69d
+
+
+---
+
+
+- [PhaseAnimator crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/PhaseAnimatorCrashOnViewClose/README.md): when closing the presented view or popping the pushed view on which it is (or 100% CPU load iOS 17.0).
+
+
+A video demonstrating how it behaves on iOS 17.2.
+
+
+upload video
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ https://github.com/user-attachments/assets/fab3cc1e-9750-47f7-a697-f84d333cd69d
 A video demonstrating how it behaves on iOS 17.2.
 
 
-upload video
+https://github.com/user-attachments/assets/0a5bdce3-ba23-477b-b75a-b90f1564261d
 
 
 ---


### PR DESCRIPTION
PhaseAnimator crash: when closing the presented view or popping the pushed view on which it is (or 100% CPU load iOS 17.0).