### PR TITLE
UIBezierPath issue: cornerRadius is incorrect for roundedRect when it exceeds ~65.5% of half of min(width,height).

### DIFF
--- a/Bugs/UIBezierPathIssueCornerRadius/MRE.swift
+++ b/Bugs/UIBezierPathIssueCornerRadius/MRE.swift
@@ -1,0 +1,34 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 2/18/25.
+//
+
+import UIKit
+
+/// UIBezierPath issue: `cornerRadius` is incorrect for `roundedRect` when it exceeds ~65.5% of half of `min(width, height)`.
+class ViewController: UIViewController {
+    private let examplePathCornerLayer = CAShapeLayer()
+    private let exampleCornerLayer = CAShapeLayer()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let edge = 200.0
+        let halfEdge = edge / 2
+        let size = CGSize(width: halfEdge * 2, height: halfEdge * 2)
+        examplePathCornerLayer.fillColor = UIColor.magenta.cgColor
+        examplePathCornerLayer.frame = .init(origin: .init(x: 64, y: 64), size: size)
+        view.layer.addSublayer(examplePathCornerLayer)
+        exampleCornerLayer.backgroundColor = UIColor.green.cgColor
+        exampleCornerLayer.frame = .init(origin: .init(x: 64, y: 64 + edge), size: size)
+        view.layer.addSublayer(exampleCornerLayer)
+
+        let cornerRadius = halfEdge * 0.7
+        examplePathCornerLayer.path = UIBezierPath(
+            roundedRect: examplePathCornerLayer.bounds,
+            cornerRadius: cornerRadius
+        ).cgPath
+        exampleCornerLayer.cornerRadius = cornerRadius
+    }
+}

--- a/Bugs/UIBezierPathIssueCornerRadius/README.md
+++ b/Bugs/UIBezierPathIssueCornerRadius/README.md
@@ -1,0 +1,33 @@
+## Problem
+
+
+UIBezierPath issue: `cornerRadius` is incorrect for `roundedRect` when it exceeds ~65.5% of half of `min(width, height)`.
+
+
+## Environment
+
+
+- Xcode 16.
+- iOS 7-18.3.
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+- No solution. 
+- Write own implementation of path corner rounding using `.addArc` / `.addCurve` / `.addQuadCurve`.
+
+
+## Demo
+
+
+A video demonstrating how it behaves on iOS 18.
+
+
+upload video.
+
+
+## Additions
+
+

--- a/Bugs/UIBezierPathIssueCornerRadius/README.md
+++ b/Bugs/UIBezierPathIssueCornerRadius/README.md
@@ -25,7 +25,7 @@ UIBezierPath issue: `cornerRadius` is incorrect for `roundedRect` when it exceed
 A video demonstrating how it behaves on iOS 18.
 
 
-upload video.
+https://github.com/user-attachments/assets/0dc54a55-ce53-4576-9094-2a40d6f73f16
 
 
 ## Additions

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ https://github.com/user-attachments/assets/537d8a71-ff94-4c93-a8d6-f37f7d085035
 A video demonstrating how it behaves on iOS 18.
 
 
-upload video.
+https://github.com/user-attachments/assets/0dc54a55-ce53-4576-9094-2a40d6f73f16
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 
 
 - [Life cycle](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/LifeCyclePushedViewController/README.md) of controllers when the new one is immediately pushed with `animation: true`.
+- [UIBezierPath issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/UIBezierPathIssueCornerRadius/README.md): `cornerRadius` is incorrect for `roundedRect` when it exceeds ~65.5% of half of `min(width, height)`.
 - [Navigation title](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationTitleQuotationMarksWhitespace/README.md) is displayed in quotation marks `" "` if a whitespace is specified as the title.
 
 
@@ -96,6 +97,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [@State issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/StateIssueSharedBetweenScenes/README.md): the same variable is shared between different scenes.
 - [PhaseAnimator crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/PhaseAnimatorCrashOnViewClose/README.md): when closing the presented view or popping the pushed view on which it is (or 100% CPU load iOS 17.0).
 - [Alert issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md): `.default` and `.cancel` buttons are recolored if alert in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
+- [UIBezierPath issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/UIBezierPathIssueCornerRadius/README.md): `cornerRadius` is incorrect for `roundedRect` when it exceeds ~65.5% of half of `min(width, height)`.
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/README.md) on drag and drop action.
 - [Navigation title](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationTitleQuotationMarksWhitespace/README.md) is displayed in quotation marks `" "` if a whitespace is specified as the title.
 
@@ -113,6 +115,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [PhaseAnimator crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/PhaseAnimatorCrashOnViewClose/README.md): when closing the presented view or popping the pushed view on which it is (or 100% CPU load iOS 17.0).
 - [SwiftData crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/SwiftDataCrashDefaultTemplate/README.md): deleting the element will result in a crash in the standard template.
 - [Alert issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AlertIssueButtonsTintAffectedByModifier/README.md): `.default` and `.cancel` buttons are recolored if alert in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
+- [UIBezierPath issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/UIBezierPathIssueCornerRadius/README.md): `cornerRadius` is incorrect for `roundedRect` when it exceeds ~65.5% of half of `min(width, height)`.
 - [Navigation title](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationTitleQuotationMarksWhitespace/README.md) is displayed in quotation marks `" "` if a whitespace is specified as the title.
 
 
@@ -377,6 +380,18 @@ A video demonstrating how it behaves on iPadOS 17.5.
 
 
 https://github.com/user-attachments/assets/537d8a71-ff94-4c93-a8d6-f37f7d085035
+
+
+---
+
+
+- [UIBezierPath issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/UIBezierPathIssueCornerRadius/README.md): `cornerRadius` is incorrect for `roundedRect` when it exceeds ~65.5% of half of `min(width, height)`.
+
+
+A video demonstrating how it behaves on iOS 18.
+
+
+upload video.
 
 
 ---


### PR DESCRIPTION
UIBezierPath issue: cornerRadius is incorrect for roundedRect when it exceeds ~65.5% of half of min(width,height).