### PR TITLE
Code completion issue: incorrect completion for `async throws` closures in initializer.

### DIFF
--- a/Bugs/CodeCompletionIssueAsyncThrowsInit/MRE.swift
+++ b/Bugs/CodeCompletionIssueAsyncThrowsInit/MRE.swift
@@ -1,0 +1,15 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 2/26/25.
+//
+
+import Foundation
+
+public class Example {
+    let getSomethingAsync: () async throws -> Bool
+
+    /// Start typing `init`:
+
+
+}

--- a/Bugs/CodeCompletionIssueAsyncThrowsInit/README.md
+++ b/Bugs/CodeCompletionIssueAsyncThrowsInit/README.md
@@ -22,7 +22,7 @@ Update to Xcode 16.3.
 Video showing how it works in Xcode 16.0.
 
 
-upload video
+https://github.com/user-attachments/assets/52eb80f0-e26a-4c93-bc76-6dde5ea6b1f0
 
 
 ## Additions

--- a/Bugs/CodeCompletionIssueAsyncThrowsInit/README.md
+++ b/Bugs/CodeCompletionIssueAsyncThrowsInit/README.md
@@ -1,0 +1,29 @@
+## Problem
+
+
+Code completion issue: incorrect completion for `async throws` closures in initializer.
+
+
+## Environment
+
+
+- Xcode 15-16.2.
+
+
+## Solution / Workaround
+
+
+Update to Xcode 16.3.
+
+
+## Demo
+
+
+Video showing how it works in Xcode 16.0.
+
+
+upload video
+
+
+## Additions
+

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Compilation error](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CompilationErrorObservableClassNameMember/README.md) if `Observable` class name is `Member`.
 - [Compilation error](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CompilationErrorPassingFunctionAsAnArgument/README.md) when passing a function isolated to an actor as an argument.
 - [Entry macro issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/EntryMacroComputedProperty/README.md): generated variable `defaultValue` is a computed property if the variable type is explicitly specified, but a stored property if the variable type is not specified explicitly.
+- [Code completion issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CodeCompletionIssueAsyncThrowsInit/README.md): incorrect completion for `async throws` closures in initializer.
 
 
 ## SwiftData
@@ -417,6 +418,18 @@ Comparison images on iOS 18 and earlier storyboard/code.
 
 ![storyboard](https://raw.githubusercontent.com/VAndrJ/awesome-apple-bugs/master/Bugs/NavigationTitleQuotationMarksWhitespace/Resources/storyboard.jpeg)
 ![code](https://raw.githubusercontent.com/VAndrJ/awesome-apple-bugs/master/Bugs/NavigationTitleQuotationMarksWhitespace/Resources/code.jpeg)
+
+
+---
+
+
+- [Code completion issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CodeCompletionIssueAsyncThrowsInit/README.md): incorrect completion for `async throws` closures in initializer.
+
+
+Video showing how it works in Xcode 16.0.
+
+
+upload video
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Comparison images on iOS 18 and earlier storyboard/code.
 Video showing how it works in Xcode 16.0.
 
 
-upload video
+https://github.com/user-attachments/assets/52eb80f0-e26a-4c93-bc76-6dde5ea6b1f0
 
 
 ---


### PR DESCRIPTION
Code completion issue: incorrect completion for `async throws` closures in initializer.