### PR TITLE
ForEach crash: when using the `Binding` variant of the init, after the animation of removing the last element has completed.

### DIFF
--- a/Bugs/ForEachCrashOnElementdeletionBindingInit/MRE.swift
+++ b/Bugs/ForEachCrashOnElementdeletionBindingInit/MRE.swift
@@ -1,0 +1,31 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 3/26/25.
+//
+
+import SwiftUI
+
+/// Example for easy reproduction.
+/// Crash occurs after deleting last element
+struct ContentView: View {
+    @State private var items: [ExampleItem] = [
+        ExampleItem(isActive: false),
+    ]
+
+    var body: some View {
+        List {
+            ForEach($items) { $item in
+                Toggle("Delete me", isOn: $item.isActive)
+            }
+            .onDelete {
+                items.remove(atOffsets: $0)
+            }
+        }
+    }
+}
+
+struct ExampleItem: Identifiable {
+    let id = UUID()
+    var isActive: Bool
+}

--- a/Bugs/ForEachCrashOnElementdeletionBindingInit/README.md
+++ b/Bugs/ForEachCrashOnElementdeletionBindingInit/README.md
@@ -1,0 +1,31 @@
+## Problem
+
+
+ForEach crash: when using the `Binding` variant of the init, after the animation of removing the last element has completed.
+
+
+## Environment
+
+
+- Xcode 16.
+- iOS 18.3-18.4beta (current; check on future versions).
+- iPadOS 18.3-18.4beta (current; check on future versions).
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+Add a delay. Extremely unreliable, but better than a guaranteed crash.
+
+
+## Demo
+
+
+A video demonstrating how it works on iOS 18.4.
+
+
+upload video.
+
+
+## Additions

--- a/Bugs/ForEachCrashOnElementdeletionBindingInit/README.md
+++ b/Bugs/ForEachCrashOnElementdeletionBindingInit/README.md
@@ -25,7 +25,7 @@ Add a delay. Extremely unreliable, but better than a guaranteed crash.
 A video demonstrating how it works on iOS 18.4.
 
 
-upload video.
+https://github.com/user-attachments/assets/3db04e00-7567-4958-a139-c8cfca07752c
 
 
 ## Additions

--- a/Bugs/ForEachCrashOnElementdeletionBindingInit/Solution.swift
+++ b/Bugs/ForEachCrashOnElementdeletionBindingInit/Solution.swift
@@ -1,0 +1,30 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 3/26/25.
+//
+
+import SwiftUI
+
+/// Example for easy reproduction.
+/// Crash occurs after deleting last element.
+struct ContentView: View {
+    @State private var items: [ExampleItem] = [
+        ExampleItem(isActive: false),
+    ]
+
+    var body: some View {
+        List {
+            ForEach($items) { $item in
+                Toggle("Delete me", isOn: $item.isActive)
+            }
+            .onDelete { offsets in
+                /// Workaround. Timing is just for example. Because the crash happens after the animation is finished. You can set "Slow Animations" to check.
+                Task {
+                    try? await Task.sleep(for: .milliseconds(500))
+                    items.remove(atOffsets: offsets)
+                }
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Images with the result.
 A video demonstrating how it works on iOS 18.4.
 
 
-upload video
+https://github.com/user-attachments/assets/3db04e00-7567-4958-a139-c8cfca07752c
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 ### SwiftUI
 
 
+- [ForEach crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ForEachCrashOnElementdeletionBindingInit/): when using the `Binding` variant of the init, after the animation of removing the last element has completed.
 - [Memory leak](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md) when applying `.searchable` and `.refreshable` modifiers together on a `ScrollView`.
 - [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in a sheet and is executed after scrolling completes.
 - [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
@@ -90,6 +91,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Memory leak](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/MemoryLeakSearchableRefreshableScrollView/README.md) when applying `.searchable` and `.refreshable` modifiers together on a `ScrollView`.
 - [Crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CrashTypedThrowsObservableObject/README.md) occurs when using a typed throws in a closure variable within an `ObservableObject`.
 - [Crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CrashNotificationCenterClosureSwift6/README.md) in Swift 6 language mode when using the closure-based version of the `UNUserNotificationCenter.requestAuthorization` function.
+- [ForEach crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ForEachCrashOnElementdeletionBindingInit/): when using the `Binding` variant of the init, after the animation of removing the last element has completed.
 - [Button action](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ButtonActionNotCancelledDuringScrollInSheet/README.md) is not canceled during scrolling in a sheet and is executed after scrolling completes.
 - [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
 - [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueHighPriorityToListScrolling/README.md): when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.
@@ -113,6 +115,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 
 - [Crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CrashTypedThrowsObservableObject/README.md) occurs when using a typed throws in a closure variable within an `ObservableObject`.
 - [Crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/CrashNotificationCenterClosureSwift6/README.md) in Swift 6 language mode when using the closure-based version of the `UNUserNotificationCenter.requestAuthorization` function.
+- [ForEach crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ForEachCrashOnElementdeletionBindingInit/): when using the `Binding` variant of the init, after the animation of removing the last element has completed.
 - [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueLongPressUpdatingNotCalled/README.md): `.updating` block is not called on `LongPressGesture`.
 - [Gesture issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/GestureIssueHighPriorityToListScrolling/README.md): when `DragGesture` is added as a `.highPriorityGesture` to a `List` or `ScrollView`, scrolling stops working.
 - [NavigationSplitView issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationSplitViewToolbarItemDisappearBackground/README.md): toolbar items disappear after the app goes to the background and then returns to the foreground.
@@ -176,6 +179,18 @@ Images with the result.
 
 ![error](https://raw.githubusercontent.com/VAndrJ/awesome-apple-bugs/master/Bugs/CrashNotificationCenterClosureSwift6/Resources/error.jpeg)
 ![solution](https://raw.githubusercontent.com/VAndrJ/awesome-apple-bugs/master/Bugs/CrashNotificationCenterClosureSwift6/Resources/solution.jpeg)
+
+
+---
+
+
+### [ForEach crash](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ForEachCrashOnElementdeletionBindingInit/): when using the `Binding` variant of the init, after the animation of removing the last element has completed.
+
+
+A video demonstrating how it works on iOS 18.4.
+
+
+upload video
 
 
 ---


### PR DESCRIPTION
ForEach crash: when using the `Binding` variant of the init, after the animation of removing the last element has completed.