### PR TITLE
Animation stops working in Lazy containers (Stacks, Grids) when navigating to the next screen and returning.

### DIFF
--- a/Bugs/AnimationIssueInLazyContainers/MRE.swift
+++ b/Bugs/AnimationIssueInLazyContainers/MRE.swift
@@ -1,0 +1,48 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 4/27/25.
+//
+
+import SwiftUI
+
+/// Example for easy reproduction.
+/// Animation stops working in Lazy containers (Stacks, Grids) when navigating to the next screen and returning.
+struct ContentView: View {
+    @State private var value = 0
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack {
+                    ForEach(0...10, id: \.self) { _ in
+                        ExampleAnimationView(value: $value)
+                    }
+                }
+            }
+            .navigationDestination(for: Int.self) {
+                Text("\($0)")
+            }
+        }
+    }
+}
+
+struct ExampleAnimationView: View {
+    @Binding var value: Int
+
+    var body: some View {
+        VStack {
+            Text("\(value)")
+                .font(.largeTitle)
+                .bold()
+                .contentTransition(.numericText(countsDown: true))
+                .animation(.default, value:value)
+                .onTapGesture {
+                    value = Int.random(in: 0...1000)
+                }
+
+            NavigationLink("Open", value: value)
+        }
+        .padding()
+    }
+}

--- a/Bugs/AnimationIssueInLazyContainers/README.md
+++ b/Bugs/AnimationIssueInLazyContainers/README.md
@@ -1,0 +1,31 @@
+## Problem
+
+
+Animation stops working in Lazy containers (Stacks, Grids) when navigating to the next screen and returning.
+
+
+## Environment
+
+
+- Xcode 16.0-16.3 (current; check on future versions).
+- iOS 18.2.
+- Swift 5/6.
+
+
+## Solution / Workaround
+
+
+Set the `id` and reset in `onAppear`.
+
+
+## Demo
+
+
+Video showing how it works on iOS 18.2.
+
+
+upload video
+
+
+## Additions
+

--- a/Bugs/AnimationIssueInLazyContainers/README.md
+++ b/Bugs/AnimationIssueInLazyContainers/README.md
@@ -24,7 +24,7 @@ Set the `id` and reset in `onAppear`.
 Video showing how it works on iOS 18.2.
 
 
-upload video
+https://github.com/user-attachments/assets/782c2b5b-8fb9-4651-a883-e286d57bab29
 
 
 ## Additions

--- a/Bugs/AnimationIssueInLazyContainers/Solution.swift
+++ b/Bugs/AnimationIssueInLazyContainers/Solution.swift
@@ -1,0 +1,54 @@
+//
+//  MRE.swift
+//
+//  Created by VAndrJ on 4/27/25.
+//
+
+import SwiftUI
+
+/// Example for easy reproduction.
+/// Animation stops working in Lazy containers (Stacks, Grids) when navigating to the next screen and returning.
+/// Solution / workaround:
+struct ContentView: View {
+    @State private var value = 0
+    @State private var id = UUID()
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                LazyVStack {
+                    ForEach(0...10, id: \.self) { _ in
+                        ExampleAnimationView(value: $value)
+                    }
+                }
+                .id(id)
+            }
+            .onAppear {
+                id = UUID()
+            }
+            .navigationDestination(for: Int.self) {
+                Text("\($0)")
+            }
+        }
+    }
+}
+
+struct ExampleAnimationView: View {
+    @Binding var value: Int
+
+    var body: some View {
+        VStack {
+            Text("\(value)")
+                .font(.largeTitle)
+                .bold()
+                .contentTransition(.numericText(countsDown: true))
+                .animation(.default, value:value)
+                .onTapGesture {
+                    value = Int.random(in: 0...1000)
+                }
+
+            NavigationLink("Open", value: value)
+        }
+        .padding()
+    }
+}

--- a/README.md
+++ b/README.md
@@ -482,7 +482,7 @@ https://github.com/user-attachments/assets/3d0d7986-6b0a-4c0c-9562-773460038d7e
 Video showing how it works on iOS 18.2.
 
 
-upload video
+https://github.com/user-attachments/assets/782c2b5b-8fb9-4651-a883-e286d57bab29
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Alert issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AlertIssueButtonsTintAffectedByModifier/): `.default` and `.cancel` buttons are recolored if alert in a `NavigationStack` that has `.tint` applied (or higher up the Views tree).
 - [List issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ListEditButtonOnlyWorksSecondTime/): the edit button only works the second time.
 - [Popover issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/PopoverArrowEdgeNotRespected/): `arrowEdge` value is not respected.
+- [Animation stops working](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationIssueInLazyContainers/) in Lazy containers (Stacks, Grids) when navigating to the next screen and returning.
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/) on drag and drop action.
 
 
@@ -112,6 +113,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [Animation glitch](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationGlitchDragAndDrop/) on drag and drop action.
 - [Popover issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/PopoverArrowEdgeNotRespected/): `arrowEdge` value is not respected.
 - [Navigation title](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationTitleQuotationMarksWhitespace/) is displayed in quotation marks `" "` if a whitespace is specified as the title.
+- [Animation stops working](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationIssueInLazyContainers/) in Lazy containers (Stacks, Grids) when navigating to the next screen and returning.
 
 
 ### iPadOS
@@ -133,6 +135,7 @@ A list of awesome bugs with SwiftUI, Swift, etc. Includes code examples and poss
 - [List issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/ListEditButtonOnlyWorksSecondTime/): the edit button only works the second time.
 - [Popover issue](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/PopoverArrowEdgeNotRespected/): `arrowEdge` value is not respected.
 - [Navigation title](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/NavigationTitleQuotationMarksWhitespace/) is displayed in quotation marks `" "` if a whitespace is specified as the title.
+- [Animation stops working](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationIssueInLazyContainers/) in Lazy containers (Stacks, Grids) when navigating to the next screen and returning.
 
 
 ### macOS
@@ -468,6 +471,18 @@ A video demonstrating how it behaves on iOS 17.
 
 
 https://github.com/user-attachments/assets/3d0d7986-6b0a-4c0c-9562-773460038d7e
+
+
+---
+
+
+### [Animation stops working](https://github.com/VAndrJ/awesome-apple-bugs/blob/main/Bugs/AnimationIssueInLazyContainers/) in Lazy containers (Stacks, Grids) when navigating to the next screen and returning.
+
+
+Video showing how it works on iOS 18.2.
+
+
+upload video
 
 
 ---


### PR DESCRIPTION
Animation stops working in Lazy containers (Stacks, Grids) when navigating to the next screen and returning.